### PR TITLE
Fixed database name in test_postgres and README.md.('hostedapi' -> 'broadcaster').

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The HTML template for the front end [is available here](https://github.com/encod
 
 * `Broadcast('memory://')`
 * `Broadcast("redis://localhost:6379")`
-* `Broadcast("postgres://localhost:5432/hostedapi")`
+* `Broadcast("postgres://localhost:5432/broadcaster")`
 * `Broadcast("kafka://localhost:9092")`
 
 ## Where next?

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -25,7 +25,7 @@ async def test_redis():
 
 @pytest.mark.asyncio
 async def test_postgres():
-    async with Broadcast('postgres://postgres:postgres@localhost:5432/hostedapi') as broadcast:
+    async with Broadcast('postgres://postgres:postgres@localhost:5432/broadcaster') as broadcast:
         async with broadcast.subscribe('chatroom') as subscriber:
             await broadcast.publish('chatroom', 'hello')
             event = await subscriber.get()


### PR DESCRIPTION
These parts missed after https://github.com/encode/broadcaster/commit/ffb09a9449aa81417e5abff33428eeb82c7dc5ea .