### PR TITLE
ci: add tests github action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,69 @@
+
+name: Tests on platforms
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  redis:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Start containers
+      run: docker-compose -f "docker-compose.yaml" up -d --build redis
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install pytest
+    - name: Run tests
+      run: pytest -m redis tests/
+    - name: Stop containers
+      if: always()
+      run: docker-compose -f "docker-compose.yaml" down
+  kafka:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Start containers
+      run: docker-compose -f "docker-compose.yaml" up -d --build kafka
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install pytest
+    - name: Run tests
+      run: pytest -m kafka tests/
+    - name: Stop containers
+      if: always()
+      run: docker-compose -f "docker-compose.yaml" down
+  postgres:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Start containers
+      run: docker-compose -f "docker-compose.yaml" up -d --build postgres
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install pytest
+    - name: Run tests
+      run: pytest -m postgres tests/
+    - name: Stop containers
+      if: always()
+      run: docker-compose -f "docker-compose.yaml" down

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -5,39 +5,44 @@ from broadcaster import Broadcast
 
 @pytest.mark.asyncio
 async def test_memory():
-    async with Broadcast('memory://') as broadcast:
-        async with broadcast.subscribe('chatroom') as subscriber:
-            await broadcast.publish('chatroom', 'hello')
+    async with Broadcast("memory://") as broadcast:
+        async with broadcast.subscribe("chatroom") as subscriber:
+            await broadcast.publish("chatroom", "hello")
             event = await subscriber.get()
-            assert event.channel == 'chatroom'
-            assert event.message == 'hello'
+            assert event.channel == "chatroom"
+            assert event.message == "hello"
 
 
 @pytest.mark.asyncio
+@pytest.mark.redis
 async def test_redis():
-    async with Broadcast('redis://localhost:6379') as broadcast:
-        async with broadcast.subscribe('chatroom') as subscriber:
-            await broadcast.publish('chatroom', 'hello')
+    async with Broadcast("redis://localhost:6379") as broadcast:
+        async with broadcast.subscribe("chatroom") as subscriber:
+            await broadcast.publish("chatroom", "hello")
             event = await subscriber.get()
-            assert event.channel == 'chatroom'
-            assert event.message == 'hello'
+            assert event.channel == "chatroom"
+            assert event.message == "hello"
 
 
 @pytest.mark.asyncio
+@pytest.mark.postgres
 async def test_postgres():
-    async with Broadcast('postgres://postgres:postgres@localhost:5432/broadcaster') as broadcast:
-        async with broadcast.subscribe('chatroom') as subscriber:
-            await broadcast.publish('chatroom', 'hello')
+    async with Broadcast(
+        "postgres://postgres:postgres@localhost:5432/broadcaster"
+    ) as broadcast:
+        async with broadcast.subscribe("chatroom") as subscriber:
+            await broadcast.publish("chatroom", "hello")
             event = await subscriber.get()
-            assert event.channel == 'chatroom'
-            assert event.message == 'hello'
+            assert event.channel == "chatroom"
+            assert event.message == "hello"
 
 
 @pytest.mark.asyncio
+@pytest.mark.kafka
 async def test_kafka():
-    async with Broadcast('kafka://localhost:9092') as broadcast:
-        async with broadcast.subscribe('chatroom') as subscriber:
-            await broadcast.publish('chatroom', 'hello')
+    async with Broadcast("kafka://localhost:9092") as broadcast:
+        async with broadcast.subscribe("chatroom") as subscriber:
+            await broadcast.publish("chatroom", "hello")
             event = await subscriber.get()
-            assert event.channel == 'chatroom'
-            assert event.message == 'hello'
+            assert event.channel == "chatroom"
+            assert event.message == "hello"


### PR DESCRIPTION
Hello, I wanted to provide an initial draft for the CI of this tool. 
It's running test for redis, postgres and kafka.
Let me know what do you think.

My idea would be to "mark" the tests relative to each platform, like `@pytest.mark.redis`. But how do you run a test for all the platforms? We could add a `mark.all_platforms`, or alternatively... we could run pytest **excluding** the other platforms relative to the test.

We'd run for redis:
```
pytest -m "not postgres and not kafka" tests/
```

This would mean that those tests with no mark, would run for all.

Thoughts?