### PR TITLE
Add websockets to example requirements

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,5 @@
 uvicorn
+websockets
 starlette
 jinja2
 broadcaster[redis,postgres,kafka]


### PR DESCRIPTION
The example doesn't work until you add websockets (gives a 400 error when trying to perform the websocket handshake), not sure if this is a new version of uvicorn that doesn't have websockets support by default? 

Changing it to `uvicorn[standard]` might also work, I can also lock the latest version numbers for each package to the example so it doesn't break in the future unexpectedly.