### PR TITLE
Unsubscribe properly for the disconnection of WebSocket

### DIFF
--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -91,11 +91,12 @@ class Broadcast:
 
             yield Subscriber(queue)
 
+        finally:
             self._subscribers[channel].remove(queue)
             if not self._subscribers.get(channel):
                 del self._subscribers[channel]
                 await self._backend.unsubscribe(channel)
-        finally:
+
             await queue.put(None)
 
 


### PR DESCRIPTION
The exception raised by WebSocket disconnection fails the unsubscribing behavior of the `Subscriber` context manager.
Fixed it by moving the unsubscribing snippet to the `finally` block.