### PR TITLE
add retuning 'int' with redis publish

### DIFF
--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -28,8 +28,8 @@ class RedisBackend(BroadcastBackend):
     async def unsubscribe(self, channel: str) -> None:
         await self._subscriber.unsubscribe([channel])
 
-    async def publish(self, channel: str, message: typing.Any) -> None:
-        await self._pub_conn.publish(channel, message)
+    async def publish(self, channel: str, message: typing.Any) -> int:
+        return await self._pub_conn.publish(channel, message)
 
     async def next_published(self) -> Event:
         message = await self._subscriber.next_published()

--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -75,8 +75,8 @@ class Broadcast:
             for queue in list(self._subscribers.get(event.channel, [])):
                 await queue.put(event)
 
-    async def publish(self, channel: str, message: Any) -> None:
-        await self._backend.publish(channel, message)
+    async def publish(self, channel: str, message: Any) -> Optional[int]:
+        return await self._backend.publish(channel, message)
 
     @asynccontextmanager
     async def subscribe(self, channel: str) -> AsyncIterator["Subscriber"]:


### PR DESCRIPTION
I think there is logic that I want to determine if it is subscribed and process it.  
For example, if I don't have any subscribers, I want to discard or retry the publish.  

I didn't know if a publish other than redis would return an int, so I made it the `Optional[int]` type in the Broadcast class and the `int` type in the RedisBackend class.

If all the subscribers are disconnected, I want the publish return to be 0, so I'd like to merge [this pull request](https://github.com/encode/broadcaster/pull/58) as well.