### PR TITLE
Fix/22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ test.db
 .coverage
 .pytest_cache/
 .mypy_cache/
-starlette.egg-info/
+broadcaster.egg-info/
 venv/
+build/
+dist/

--- a/broadcaster/_backends/kafka.py
+++ b/broadcaster/_backends/kafka.py
@@ -1,4 +1,3 @@
-import asyncio
 import typing
 from urllib.parse import urlparse
 
@@ -14,9 +13,8 @@ class KafkaBackend(BroadcastBackend):
         self._consumer_channels: typing.Set = set()
 
     async def connect(self) -> None:
-        loop = asyncio.get_event_loop()
-        self._producer = AIOKafkaProducer(loop=loop, bootstrap_servers=self._servers)
-        self._consumer = AIOKafkaConsumer(loop=loop, bootstrap_servers=self._servers)
+        self._producer = AIOKafkaProducer(bootstrap_servers=self._servers)
+        self._consumer = AIOKafkaConsumer(bootstrap_servers=self._servers)
         await self._producer.start()
         await self._consumer.start()
 
@@ -29,7 +27,7 @@ class KafkaBackend(BroadcastBackend):
         self._consumer.subscribe(topics=self._consumer_channels)
 
     async def unsubscribe(self, channel: str) -> None:
-        await self._consumer.unsubscribe()
+        self._consumer.unsubscribe()
 
     async def publish(self, channel: str, message: typing.Any) -> None:
         await self._producer.send_and_wait(channel, message.encode("utf8"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,14 +11,14 @@ wheel
 
 # Tests & Linting
 autoflake
-black==20.8b1
+black==22.3.0
 coverage==5.3
 flake8
 flake8-bugbear
 flake8-pie==0.5.*
 isort==5.*
 mypy
-pytest==5.*
+pytest==7.*
 pytest-asyncio
 pytest-trio
 trio

--- a/scripts/check
+++ b/scripts/check
@@ -11,4 +11,4 @@ set -x
 ${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
-${PREFIX}isort --check --diff --project=httpx $SOURCE_FILES
+${PREFIX}isort --check --diff --project=broadcaster $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,10 +4,10 @@ export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
-export SOURCE_FILES="httpx tests"
+export SOURCE_FILES="broadcaster tests"
 
 set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}isort --project=httpx $SOURCE_FILES
+${PREFIX}isort --project=broadcaster $SOURCE_FILES
 ${PREFIX}black --target-version=py37 $SOURCE_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,10 @@ combine_as_imports = True
 
 [tool:pytest]
 addopts = -rxXs
+asyncio_mode = strict
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
 
 [coverage:run]
 omit = venv/*
-include = httpx/*, tests/*
+include = broadcaster/*, tests/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Check for #22"""
+
+import asyncio
+import functools
+
+import pytest_asyncio
+
+from broadcaster import Broadcast
+from broadcaster._backends.kafka import KafkaBackend
+
+
+async def __has_topic_now(client, topic):
+    if await client.force_metadata_update():
+        if topic in client.cluster.topics():
+            print(f'Topic "{topic}" exists')
+            return True
+    return False
+
+
+async def __wait_has_topic(client, topic, *, timeout_sec=5):
+    poll_time_sec = 1 / 10000
+    from datetime import datetime
+
+    pre = datetime.now()
+    while True:
+        if (datetime.now() - pre).total_seconds() >= timeout_sec:
+            raise ValueError(f'No topic "{topic}" exists')
+        if await __has_topic_now(client, topic):
+            return
+        await asyncio.sleep(poll_time_sec)
+
+
+def kafka_backend_setup(kafka_backend):
+    """Block until consumer client contains the topic"""
+    subscribe_impl = kafka_backend.subscribe
+
+    @functools.wraps(subscribe_impl)
+    async def subscribe(channel: str) -> None:
+        await subscribe_impl(channel)
+        await __wait_has_topic(kafka_backend._consumer._client, channel)
+
+    kafka_backend.subscribe = subscribe
+
+
+BROADCASTS_SETUP = {
+    KafkaBackend: kafka_backend_setup,
+}
+
+
+@pytest_asyncio.fixture(scope="function")
+async def setup_broadcast(request):
+    url = request.param
+    async with Broadcast(url) as broadcast:
+        backend = broadcast._backend
+        for klass, setup in BROADCASTS_SETUP.items():
+            if isinstance(backend, klass):
+                setup(backend)
+                break
+        yield broadcast

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -28,3 +28,35 @@ async def test_broadcast(setup_broadcast):
             event = await subscriber.get()
             assert event.channel == channel
             assert event.message == msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(["setup_broadcast"], URLS, indirect=True)
+async def test_sub(setup_broadcast):
+    uid = uuid4()
+    channel1 = f"chatroom-{uid}1"
+    channel2 = f"chatroom-{uid}2"
+
+    to_sub = [
+        setup_broadcast._backend.subscribe(channel1),
+        setup_broadcast._backend.subscribe(channel2),
+    ]
+    await asyncio.gather(*to_sub)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(["setup_broadcast"], URLS, indirect=True)
+async def test_unsub(setup_broadcast):
+    uid = uuid4()
+    channel1 = f"chatroom-{uid}1"
+    channel2 = f"chatroom-{uid}2"
+
+    await setup_broadcast._backend.subscribe(channel1)
+    await setup_broadcast._backend.subscribe(channel2)
+
+    to_unsub = [
+        setup_broadcast._backend.unsubscribe(channel1),
+        setup_broadcast._backend.unsubscribe(channel2),
+    ]
+
+    await asyncio.gather(*to_unsub)


### PR DESCRIPTION
* test: add concurrent checks   
    * group together fixtures for backend testing
    * Add per-backend setup to allow slow initialization.
      This is specially important as kafka subscribe can return while the consumer
      is not ready. See related test setup upstream:
        - https://github.com/aio-libs/aiokafka/blob/2c54e10c57760f779961a8c2f5df8ad609ef6983/tests/test_consumer.py#L433
        - https://github.com/aio-libs/aiokafka/blob/2c54e10c57760f779961a8c2f5df8ad609ef6983/tests/_testutil.py#L376
        - https://github.com/aio-libs/aiokafka/blob/2c54e10c57760f779961a8c2f5df8ad609ef6983/tests/_testutil.py#L364

* chore: update remnants, packages
* fix(backend/kafka): consumer unsubscribe not awaitable
* fix(backend/postgres): allow concurrent pubs
    
    This fix adds a lock (asyncio.Event based) to avoid
    `asyncpg.exceptions._base.InterfaceError: cannot perform operation: another operation is in progress`
    
fixes #22
fixes #42