### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
 
     services:
       zookeeper:

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
Changes:
- Add Python 3.10 & 3.11 (dev) to the pipeline.
- Add Python 3.9, 3.10 and 3.11 to the PyPI classifiers.
