### PR TITLE
Set timeout on tests step

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -20,7 +20,7 @@ jobs:
       zookeeper:
         image: confluentinc/cp-zookeeper
         ports:
-        - 32181:32181
+          - 32181:32181
         env:
           ZOOKEEPER_CLIENT_PORT: 32181
           ALLOW_ANONYMOUS_LOGIN: yes
@@ -28,8 +28,8 @@ jobs:
       kafka:
         image: confluentinc/cp-kafka
         ports:
-        - 9092:9092
-        - 29092:29092
+          - 9092:9092
+          - 29092:29092
         env:
           KAFKA_ZOOKEEPER_CONNECT: "zookeeper:32181"
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
@@ -41,7 +41,7 @@ jobs:
       redis:
         image: redis:alpine
         ports:
-        - 6379:6379
+          - 6379:6379
       postgres:
         image: postgres:12
         env:
@@ -50,7 +50,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_USER: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
 
     steps:
       - uses: "actions/checkout@v2"
@@ -64,6 +64,7 @@ jobs:
       - name: "Build package & docs"
         run: "scripts/build"
       - name: "Run tests"
+        timeout-minutes: 1
         run: "scripts/test"
       - name: "Enforce coverage"
         run: "scripts/coverage"


### PR DESCRIPTION
I know this is a bad practice, but we have a test hanging _randomly_ (besides the kafka one, which based on the issues I suspect is the redis one), and one of the pipelines ran for 43 minutes. I don't want to waste resources again.

Until the unknown problematic test is fixed, let's use this timeout.