### PR TITLE
Add redis backed with RedisPy

### DIFF
--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -1,7 +1,8 @@
-import typing
+from typing import Any
 from urllib.parse import urlparse
 
-import asyncio_redis
+import redis.asyncio as redis
+from redis.asyncio.client import PubSub
 
 from .._base import Event
 from .base import BroadcastBackend
@@ -14,25 +15,35 @@ class RedisBackend(BroadcastBackend):
         self._port = parsed_url.port or 6379
         self._password = parsed_url.password or None
 
+        self._sub_conn: PubSub | None = None
+        self._pub_conn: PubSub | None = None
+
     async def connect(self) -> None:
         kwargs = {"host": self._host, "port": self._port, "password": self._password}
-        self._pub_conn = await asyncio_redis.Connection.create(**kwargs)
-        self._sub_conn = await asyncio_redis.Connection.create(**kwargs)
-        self._subscriber = await self._sub_conn.start_subscribe()
+        self._pub_conn = redis.Redis(**kwargs).pubsub()
+        self._sub_conn = redis.Redis(**kwargs).pubsub()
 
     async def disconnect(self) -> None:
-        self._pub_conn.close()
-        self._sub_conn.close()
+        await self._pub_conn.close()
+        await self._sub_conn.close()
 
     async def subscribe(self, channel: str) -> None:
-        await self._subscriber.subscribe([channel])
+        await self._sub_conn.subscribe(channel)
 
     async def unsubscribe(self, channel: str) -> None:
-        await self._subscriber.unsubscribe([channel])
+        await self._sub_conn.unsubscribe(channel)
 
-    async def publish(self, channel: str, message: typing.Any) -> None:
-        await self._pub_conn.publish(channel, message)
+    async def publish(self, channel: str, message: Any) -> None:
+        await self._pub_conn.execute_command("PUBLISH", channel, message)
 
     async def next_published(self) -> Event:
-        message = await self._subscriber.next_published()
-        return Event(channel=message.channel, message=message.value)
+        message = None
+        # get_message with timeout=None can return None
+        while not message:
+            #
+            message = await self._sub_conn.get_message(timeout=None)
+        event = Event(
+            channel=message["channel"].decode(),
+            message=message["data"].decode(),
+        )
+        return event

--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -42,8 +42,7 @@ class RedisBackend(BroadcastBackend):
         while not message:
             #
             message = await self._sub_conn.get_message(timeout=None)
-        event = Event(
+        return Event(
             channel=message["channel"].decode(),
             message=message["data"].decode(),
         )
-        return event

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     package_data={"broadcaster": ["py.typed"]},
     include_package_data=True,
     extras_require={
-        "redis": ["asyncio-redis"],
+        "redis": ["redis"],
         "postgres": ["asyncpg"],
         "kafka": ["aiokafka"],
         "test": ["pytest", "pytest-asyncio"],


### PR DESCRIPTION
# Rationale
Broadcaster uses `asyncio-redis` in its `RedisBackend`. `asyncio-redis` is not actively maintained at the moment.

`RedisPy` (https://github.com/redis/redis-py) is the maintained Redis client for Python, and it has had AsyncIO support for quite some time.

# Pull Request Content

This PR provides an updated Redis backend using `RedisPy`.

# Problems faced

`RedisPy` doesn't allow listening for PubSub messages if the connection is not subscribed to any channels:

https://github.com/redis/redis-py/blob/master/redis/asyncio/client.py#L807

To solve this, the code of the `Broadcaster` class has been changed to start the listener task only after the first subscription to a channel.

Another solution would be to subscribe to an arbitrary channel in the `connect` method of Redis backend. I am not sure that I like this workaround.

However, I have not tested that these changes to the `Broadcaster` class do not break other backends.