### PR TITLE
Use memory:// in demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from starlette.routing import Route, WebSocketRoute
 from starlette.templating import Jinja2Templates
 
 
-broadcast = Broadcast("redis://localhost:6379")
+broadcast = Broadcast("memory://")
 templates = Jinja2Templates("templates")
 
 


### PR DESCRIPTION
Suggestion to use `memory://` in the demo code to reduce the barrier to entry. It works well, and for some of us with Redis auth setup, removes the need to figure that out.

Was also tempted to also suggest `templates = Jinja2Templates(".")` for the templates, and so then everything can be served from the same folder easily. NB. I didn't make that change in this PR though.