### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
 
     services:
       zookeeper:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The HTML template for the front end [is available here](https://github.com/encod
 
 ## Requirements
 
-Python 3.7+
+Python 3.8+
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def get_packages(package):
 
 setup(
     name="broadcaster",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     version=get_version("broadcaster"),
     url="https://github.com/encode/broadcaster",
     license="BSD",
@@ -59,7 +59,6 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Internet :: WWW/HTTP",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Drop Python 3.7 support.

Issue: https://github.com/encode/broadcaster/issues/94