### PR TITLE
Clean up channel subscription on exception

### DIFF
--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -88,13 +88,13 @@ class Broadcast:
                 self._subscribers[channel] = set([queue])
             else:
                 self._subscribers[channel].add(queue)
-
-            yield Subscriber(queue)
-
-            self._subscribers[channel].remove(queue)
-            if not self._subscribers.get(channel):
-                del self._subscribers[channel]
-                await self._backend.unsubscribe(channel)
+            try:
+                yield Subscriber(queue)
+            finally:
+                self._subscribers[channel].remove(queue)
+                if not self._subscribers.get(channel):
+                    del self._subscribers[channel]
+                    await self._backend.unsubscribe(channel)
         finally:
             await queue.put(None)
 


### PR DESCRIPTION
The `subscribe` context manager does not currently `unsubscribe` if an exception is thrown from within it.