### PR TITLE
Upgrade: Transitioning from asyncio-redis to redis-py with SSL Support

### DIFF
--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -15,8 +15,13 @@ class RedisBackend(BroadcastBackend):
         self._port = parsed_url.port or 6379
         self._password = parsed_url.password or None
         self._ssl = parsed_url.scheme == "rediss"
-        self.kwargs = {"host": self._host, "port": self._port, "password": self._password, "ssl": self._ssl}
-        
+        self.kwargs = {
+            "host": self._host,
+            "port": self._port,
+            "password": self._password,
+            "ssl": self._ssl,
+        }
+
         self._sub_conn: PubSub | None = None
         self._pub_conn: PubSub | None = None
 
@@ -40,7 +45,9 @@ class RedisBackend(BroadcastBackend):
     async def next_published(self) -> Event:
         message = None
         while not message:
-            message = await self._sub_conn.get_message(ignore_subscribe_messages=True, timeout=None)
+            message = await self._sub_conn.get_message(
+                ignore_subscribe_messages=True, timeout=None
+            )
         event = Event(
             channel=message["channel"].decode(),
             message=message["data"].decode(),

--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -43,7 +43,7 @@ class RedisBackend(BroadcastBackend):
     async def publish(self, channel: str, message: Any) -> None:
         try:
             await self._pub_conn.execute_command("PUBLISH", channel, message)
-        except redis.ConnectionError:
+        except (redis.ConnectionError, redis.TimeoutError):
             await asyncio.sleep(1)
             self._pub_conn = redis.Redis(**self.kwargs).pubsub()
             await self.publish(channel, message)

--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -14,15 +14,15 @@ class RedisBackend(BroadcastBackend):
         self._host = parsed_url.hostname or "localhost"
         self._port = parsed_url.port or 6379
         self._password = parsed_url.password or None
-
+        self._ssl = parsed_url.scheme == "rediss"
+        self.kwargs = {"host": self._host, "port": self._port, "password": self._password, "ssl": self._ssl}
+        
         self._sub_conn: PubSub | None = None
         self._pub_conn: PubSub | None = None
 
     async def connect(self) -> None:
-        kwargs = {"host": self._host, "port": self._port, "password": self._password}
-        print(kwargs)
-        self._pub_conn = redis.Redis(**kwargs).pubsub()
-        self._sub_conn = redis.Redis(**kwargs).pubsub()
+        self._pub_conn = redis.Redis(**self.kwargs).pubsub()
+        self._sub_conn = redis.Redis(**self.kwargs).pubsub()
 
     async def disconnect(self) -> None:
         await self._pub_conn.close()


### PR DESCRIPTION
We've replaced asyncio-redis with redis-py and added SSL support.

asyncio-redis is no longer actively maintained, whereas redis-py is actively developed and fully supports asyncio.

This PR addresses issue #107 