### PR TITLE
Allow user backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ and pass it to the `broadcaster` via `backend` argument.
 
 ```python
 from broadcaster import Broadcaster, BroadcastBackend
-class MyBackend(BroadcastBackend): ...
+
+class MyBackend(BroadcastBackend):
+    ...
 
 broadcaster = Broadcaster(backend=MyBackend())
-
-```
 
 ## Where next?
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Python 3.8+
 * `Broadcast("postgres://localhost:5432/broadcaster")`
 * `Broadcast("kafka://localhost:9092")`
 
+
+### Using custom backends
+
+You can create your own backend and use it with `broadcaster`.
+To do that you need to create a class which extends from `BroadcastBackend` 
+and pass it to the `broadcaster` via `backend` argument.
+
+```python
+from broadcaster import Broadcaster, BroadcastBackend
+class MyBackend(BroadcastBackend): ...
+
+broadcaster = Broadcaster(backend=MyBackend())
+
+```
+
 ## Where next?
 
 At the moment `broadcaster` is in Alpha, and should be considered a working design document.

--- a/broadcaster/__init__.py
+++ b/broadcaster/__init__.py
@@ -1,4 +1,5 @@
 from ._base import Broadcast, Event
+from ._backends.base import BroadcastBackend
 
 __version__ = "0.2.0"
-__all__ = ["Broadcast", "Event"]
+__all__ = ["Broadcast", "Event", "BroadcastBackend"]

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -63,8 +63,11 @@ async def test_unknown_backend():
     with pytest.raises(ValueError, match="Unsupported backend"):
         async with Broadcast(url="unknown://"):
             pass
-        
+
+
 @pytest.mark.asyncio
 async def test_needs_url_or_backend():
-    with pytest.raises(AssertionError, match="Either `url` or `backend` must be provided."):
+    with pytest.raises(
+        AssertionError, match="Either `url` or `backend` must be provided."
+    ):
         Broadcast()

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -1,7 +1,35 @@
 import pytest
+import typing
+import asyncio
 
-from broadcaster import Broadcast
-from broadcaster._backends.memory import MemoryBackend
+from broadcaster import Broadcast, BroadcastBackend, Event
+
+
+class CustomBackend(BroadcastBackend):
+    def __init__(self, url: str):
+        self._subscribed: typing.Set = set()
+
+    async def connect(self) -> None:
+        self._published: asyncio.Queue = asyncio.Queue()
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def subscribe(self, channel: str) -> None:
+        self._subscribed.add(channel)
+
+    async def unsubscribe(self, channel: str) -> None:
+        self._subscribed.remove(channel)
+
+    async def publish(self, channel: str, message: typing.Any) -> None:
+        event = Event(channel=channel, message=message)
+        await self._published.put(event)
+
+    async def next_published(self) -> Event:
+        while True:
+            event = await self._published.get()
+            if event.channel in self._subscribed:
+                return event
 
 
 @pytest.mark.asyncio
@@ -49,7 +77,7 @@ async def test_kafka():
 
 @pytest.mark.asyncio
 async def test_custom():
-    backend = MemoryBackend("")
+    backend = CustomBackend("")
     async with Broadcast(backend=backend) as broadcast:
         async with broadcast.subscribe("chatroom") as subscriber:
             await broadcast.publish("chatroom", "hello")

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -1,6 +1,7 @@
 import pytest
 
 from broadcaster import Broadcast
+from broadcaster._backends.memory import MemoryBackend
 
 
 @pytest.mark.asyncio
@@ -44,3 +45,26 @@ async def test_kafka():
             event = await subscriber.get()
             assert event.channel == "chatroom"
             assert event.message == "hello"
+
+
+@pytest.mark.asyncio
+async def test_custom():
+    backend = MemoryBackend("")
+    async with Broadcast(backend=backend) as broadcast:
+        async with broadcast.subscribe("chatroom") as subscriber:
+            await broadcast.publish("chatroom", "hello")
+            event = await subscriber.get()
+            assert event.channel == "chatroom"
+            assert event.message == "hello"
+
+
+@pytest.mark.asyncio
+async def test_unknown_backend():
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        async with Broadcast(url="unknown://"):
+            pass
+        
+@pytest.mark.asyncio
+async def test_needs_url_or_backend():
+    with pytest.raises(AssertionError, match="Either `url` or `backend` must be provided."):
+        Broadcast()


### PR DESCRIPTION
This PR allows usage of custom user backends. Users can build their own backends and not be dependent on the shipped backends.

```python
backend = MemoryBackend("")
async with Broadcast(backend=backend) as broadcast:
    async with broadcast.subscribe("chatroom") as subscriber:
        await broadcast.publish("chatroom", "hello")
        event = await subscriber.get()
        assert event.channel == "chatroom"
        assert event.message == "hello"
```

Also closes https://github.com/encode/broadcaster/issues/90