### PR TITLE
Fix subscriber not properly unsubscribing when an exception is raised inside the context manager

### DIFF
--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -90,12 +90,11 @@ class Broadcast:
                 self._subscribers[channel].add(queue)
 
             yield Subscriber(queue)
-
+        finally:
             self._subscribers[channel].remove(queue)
             if not self._subscribers.get(channel):
                 del self._subscribers[channel]
                 await self._backend.unsubscribe(channel)
-        finally:
             await queue.put(None)
 
 

--- a/tests/test_unsubscribe.py
+++ b/tests/test_unsubscribe.py
@@ -1,0 +1,29 @@
+import pytest
+from broadcaster import Broadcast
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe():
+    """The queue should be removed when the context manager is left."""
+    broadcast = Broadcast("memory://")
+    await broadcast.connect()
+
+    async with broadcast.subscribe("chatroom"):
+        pass
+
+    assert "chatroom" not in broadcast._subscribers
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_w_exception():
+    """In case an exception is raised inside the context manager, the queue should be removed."""
+    broadcast = Broadcast("memory://")
+    await broadcast.connect()
+
+    try:
+        async with broadcast.subscribe("chatroom"):
+            raise RuntimeError("MyException")
+    except RuntimeError:
+        pass
+
+    assert "chatroom" not in broadcast._subscribers

--- a/tests/test_unsubscribe.py
+++ b/tests/test_unsubscribe.py
@@ -5,25 +5,21 @@ from broadcaster import Broadcast
 @pytest.mark.asyncio
 async def test_unsubscribe():
     """The queue should be removed when the context manager is left."""
-    broadcast = Broadcast("memory://")
-    await broadcast.connect()
+    async with Broadcast("memory://") as broadcast:
+        async with broadcast.subscribe("chatroom"):
+            pass
 
-    async with broadcast.subscribe("chatroom"):
-        pass
-
-    assert "chatroom" not in broadcast._subscribers
+        assert "chatroom" not in broadcast._subscribers
 
 
 @pytest.mark.asyncio
 async def test_unsubscribe_w_exception():
     """In case an exception is raised inside the context manager, the queue should be removed."""
-    broadcast = Broadcast("memory://")
-    await broadcast.connect()
+    async with Broadcast("memory://") as broadcast:
+        try:
+            async with broadcast.subscribe("chatroom"):
+                raise RuntimeError("MyException")
+        except RuntimeError:
+            pass
 
-    try:
-        async with broadcast.subscribe("chatroom"):
-            raise RuntimeError("MyException")
-    except RuntimeError:
-        pass
-
-    assert "chatroom" not in broadcast._subscribers
+        assert "chatroom" not in broadcast._subscribers


### PR DESCRIPTION
Turned out to be a duplicate of this:
https://github.com/encode/broadcaster/pull/58

But this one also contains testcases :)