### PR TITLE
Ensure RedisBackend Listener Restarts on Resubscription

### DIFF
--- a/broadcaster/_backends/redis.py
+++ b/broadcaster/_backends/redis.py
@@ -28,8 +28,11 @@ class RedisBackend(BroadcastBackend):
     async def subscribe(self, channel: str) -> None:
         self._ready.set()
         await self._pubsub.subscribe(channel)
+        if self._listener.done():
+            self._listener = asyncio.create_task(self._pubsub_listener())
 
     async def unsubscribe(self, channel: str) -> None:
+        self._ready.clear()
         await self._pubsub.unsubscribe(channel)
 
     async def publish(self, channel: str, message: typing.Any) -> None:


### PR DESCRIPTION
This pull request addresses a specific issue in the RedisBackend class where if all subscribers to a channel were unsubscribed, the listener task would complete and not restart upon new subscriptions. This led to a scenario where messages could be missed if new subscriptions were added after all others were removed.