### PR TITLE
feat: :sparkles: fix redis stream empty subscribe bug && supported redis stream cached (#148)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test.db
 venv/
 build/
 dist/
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Python 3.8+
 * `Broadcast('memory://')`
 * `Broadcast("redis://localhost:6379")`
 * `Broadcast("redis-stream://localhost:6379")`
+* `Broadcast("redis-stream-cached://localhost:6379")`
 * `Broadcast("postgres://localhost:5432/broadcaster")`
 * `Broadcast("kafka://localhost:9092")`
 

--- a/broadcaster/__init__.py
+++ b/broadcaster/__init__.py
@@ -1,4 +1,5 @@
-from ._base import Broadcast, Event
+from ._base import Broadcast
+from ._event import Event
 from .backends.base import BroadcastBackend
 
 __version__ = "0.3.1"

--- a/broadcaster/_event.py
+++ b/broadcaster/_event.py
@@ -1,0 +1,10 @@
+class Event:
+    def __init__(self, channel: str, message: str) -> None:
+        self.channel = channel
+        self.message = message
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Event) and self.channel == other.channel and self.message == other.message
+
+    def __repr__(self) -> str:
+        return f"Event(channel={self.channel!r}, message={self.message!r})"

--- a/broadcaster/backends/base.py
+++ b/broadcaster/backends/base.py
@@ -1,6 +1,8 @@
-from typing import Any
+from __future__ import annotations
 
-from .._base import Event
+from typing import Any, AsyncGenerator
+
+from .._event import Event
 
 
 class BroadcastBackend:
@@ -23,4 +25,17 @@ class BroadcastBackend:
         raise NotImplementedError()
 
     async def next_published(self) -> Event:
+        raise NotImplementedError()
+
+
+class BroadcastCacheBackend(BroadcastBackend):
+    async def get_current_channel_id(self, channel: str):
+        raise NotImplementedError()
+
+    async def get_history_messages(
+        self,
+        channel: str,
+        msg_id: int | bytes | str | memoryview,
+        count: int | None = None,
+    ) -> AsyncGenerator[Event, None]:
         raise NotImplementedError()

--- a/broadcaster/backends/kafka.py
+++ b/broadcaster/backends/kafka.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 
-from .._base import Event
+from .._event import Event
 from .base import BroadcastBackend
 
 

--- a/broadcaster/backends/memory.py
+++ b/broadcaster/backends/memory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import typing
 
-from .._base import Event
+from .._event import Event
 from .base import BroadcastBackend
 
 

--- a/broadcaster/backends/postgres.py
+++ b/broadcaster/backends/postgres.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import asyncpg
 
-from .._base import Event
+from .._event import Event
 from .base import BroadcastBackend
 
 

--- a/broadcaster/backends/redis.py
+++ b/broadcaster/backends/redis.py
@@ -5,8 +5,8 @@ import typing
 
 from redis import asyncio as redis
 
-from .._base import Event
-from .base import BroadcastBackend
+from .._event import Event
+from .base import BroadcastBackend, BroadcastCacheBackend
 
 
 class RedisBackend(BroadcastBackend):
@@ -88,14 +88,20 @@ class RedisStreamBackend(BroadcastBackend):
 
     async def unsubscribe(self, channel: str) -> None:
         self.streams.pop(channel, None)
+        if not self.streams:
+            self._ready.clear()
 
     async def publish(self, channel: str, message: typing.Any) -> None:
         await self._producer.xadd(channel, {"message": message})
 
     async def wait_for_messages(self) -> list[StreamMessageType]:
-        await self._ready.wait()
         messages = None
         while not messages:
+            if not self.streams:
+                # 1. save cpu usage
+                # 2. redis raise expection when self.streams is empty
+                self._ready.clear()
+            await self._ready.wait()
             messages = await self._consumer.xread(self.streams, count=1, block=100)
         return messages
 
@@ -108,3 +114,75 @@ class RedisStreamBackend(BroadcastBackend):
             channel=stream.decode("utf-8"),
             message=message.get(b"message", b"").decode("utf-8"),
         )
+
+
+class RedisStreamCachedBackend(BroadcastCacheBackend):
+    def __init__(self, url: str):
+        url = url.replace("redis-stream-cached", "redis", 1)
+        self.streams: dict[bytes | str | memoryview, int | bytes | str | memoryview] = {}
+        self._ready = asyncio.Event()
+        self._producer = redis.Redis.from_url(url)
+        self._consumer = redis.Redis.from_url(url)
+
+    async def connect(self) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        await self._producer.aclose()
+        await self._consumer.aclose()
+
+    async def subscribe(self, channel: str) -> None:
+        # read from beginning
+        last_id = "0"
+        self.streams[channel] = last_id
+        self._ready.set()
+
+    async def unsubscribe(self, channel: str) -> None:
+        self.streams.pop(channel, None)
+        if not self.streams:
+            self._ready.clear()
+
+    async def publish(self, channel: str, message: typing.Any) -> None:
+        await self._producer.xadd(channel, {"message": message})
+
+    async def wait_for_messages(self) -> list[StreamMessageType]:
+        messages = None
+        while not messages:
+            if not self.streams:
+                # 1. save cpu usage
+                # 2. redis raise expection when self.streams is empty
+                self._ready.clear()
+            await self._ready.wait()
+            messages = await self._consumer.xread(self.streams, count=1, block=100)
+        return messages
+
+    async def next_published(self) -> Event:
+        messages = await self.wait_for_messages()
+        stream, events = messages[0]
+        _msg_id, message = events[0]
+        self.streams[stream.decode("utf-8")] = _msg_id.decode("utf-8")
+        return Event(
+            channel=stream.decode("utf-8"),
+            message=message.get(b"message", b"").decode("utf-8"),
+        )
+
+    async def get_current_channel_id(self, channel: str):
+        try:
+            info = await self._consumer.xinfo_stream(channel)
+            last_id = info["last-generated-id"]
+        except redis.ResponseError:
+            last_id = "0"
+        return last_id
+
+    async def get_history_messages(
+        self,
+        channel: str,
+        msg_id: int | bytes | str | memoryview,
+        count: int | None = None,
+    ) -> typing.AsyncGenerator[Event, None]:
+        messages = await self._consumer.xrevrange(channel, max=msg_id, count=count)
+        for _, message in reversed(messages or []):
+            yield Event(
+                channel=channel,
+                message=message.get(b"message", b"").decode("utf-8"),
+            )

--- a/example/app.py
+++ b/example/app.py
@@ -1,5 +1,7 @@
-import os
+from __future__ import annotations
 
+import os
+from pathlib import Path
 
 import anyio
 from starlette.applications import Starlette
@@ -10,8 +12,9 @@ from broadcaster import Broadcast
 
 BROADCAST_URL = os.environ.get("BROADCAST_URL", "memory://")
 
-broadcast = Broadcast(BROADCAST_URL)
-templates = Jinja2Templates("example/templates")
+templates_dir = Path(__file__).parent / "templates"
+broadcast = Broadcast("redis-stream-cached://localhost:6379/8")
+templates = Jinja2Templates(templates_dir)
 
 
 async def homepage(request):
@@ -51,5 +54,13 @@ routes = [
 
 
 app = Starlette(
-    routes=routes, on_startup=[broadcast.connect], on_shutdown=[broadcast.disconnect],
+    routes=routes,
+    on_startup=[broadcast.connect],
+    on_shutdown=[broadcast.disconnect],
 )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=7777)

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -72,6 +72,29 @@ async def test_redis_stream():
 
 
 @pytest.mark.asyncio
+async def test_redis_stream_cache():
+    messages = ["hello", "I'm cached"]
+    async with Broadcast("redis-stream-cached://localhost:6379") as broadcast:
+        await broadcast.publish("chatroom_cached", messages[0])
+        await broadcast.publish("chatroom_cached", messages[1])
+        await broadcast.publish("chatroom_cached", "quit")
+        sub1_messages = []
+        async with broadcast.subscribe("chatroom_cached") as subscriber:
+            async for event in subscriber:
+                if event.message == "quit":
+                    break
+                sub1_messages.append(event.message)
+        sub2_messages = []
+        async with broadcast.subscribe("chatroom_cached") as subscriber:
+            async for event in subscriber:
+                if event.message == "quit":
+                    break
+                sub2_messages.append(event.message)
+
+        assert sub1_messages == sub2_messages == messages
+
+
+@pytest.mark.asyncio
 async def test_postgres():
     async with Broadcast("postgres://postgres:postgres@localhost:5432/broadcaster") as broadcast:
         async with broadcast.subscribe("chatroom") as subscriber:


### PR DESCRIPTION
- When redis stream subscribing and then unsubscribing leaving the subscription list empty, an error is thrown.
- Supported redis stream cached.