### PR TITLE
✨ Add RedisPydanticStream backend

### DIFF
--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -43,6 +43,11 @@ class Broadcast:
 
             return RedisStreamBackend(url)
 
+        elif parsed_url.scheme == "redis-pydantic-stream":
+            from broadcaster.backends.redis import RedisPydanticStreamBackend
+
+            return RedisPydanticStreamBackend(url)
+
         elif parsed_url.scheme in ("postgres", "postgresql"):
             from broadcaster.backends.postgres import PostgresBackend
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 redis = ["redis"]
 postgres = ["asyncpg"]
 kafka = ["aiokafka"]
+pydantic = ["pydantic", "redis"]
 test =  ["pytest", "pytest-asyncio"]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e .[redis,postgres,kafka]
+-e .[redis,postgres,kafka,pydantic]
 
 # Documentation
 mkdocs==1.5.3


### PR DESCRIPTION
Provides a new backend--`RedisPydanticStreamBackend`--derived from `RedisStreamBackend`. Instead of a `message: str` being passed to `publish`, it takes a Pydantic `BaseModel`. On the other side, it deserializes the object back into a Pydantic model. Now that I'm reviewing this, I think it'd be beneficial to add the following to `publish`:

```diff
    async def publish(self: typing.Self, channel: str, message: BaseModel) -> None:
        """Publish a message to a channel."""
        msg_type: str = message.__class__.__name__
+
+        if msg_type not in self._module_cache:
+            self._module_cache[msg_type] = message.__class__
+
        message_json: str = message.model_dump_json()
        await self._producer.xadd(channel, {"msg_type": msg_type, "message": message_json})
```

But it would only be useful in rare cases (dynamically created models or models at lower-than-module scope) or specifically in the test case, dropping the import and class declaration into the test itself.